### PR TITLE
Add android build workflow & Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @aminekarimii @Rajdaoui-Zouhair

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,27 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ "dev" ]
+  pull_request:
+    branches: [ "dev" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build
+


### PR DESCRIPTION
## Features
* Add a workflow that runs `./gradlew build` on each push or PR on dev branch.
*[example:](https://github.com/driouecheMed/analytiks/pull/4)*
![image](https://user-images.githubusercontent.com/57846711/224491770-e0fadee4-4c04-4842-85d0-0e95087e92c5.png)

* Add CODOWNERS file.

## Improvements
* For android workflow you can add also `./gradlew spotlessCheck` for code lint and `./gradlew apiCheck`.
* Update repository settings for taking full advantage from CODOWNERS.
 