### PR TITLE
Only trigger CI after PR approved

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,14 +1,14 @@
 name: Android CI
 
 on:
-  push:
-    branches: [ "dev" ]
-  pull_request:
+  pull_request_review:
+    types: [submitted]
     branches: [ "dev" ]
 
 jobs:
   build:
 
+    if: github.event.review.state == 'approved'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
the current solution trigger CI workflow after each push & PR event, which lead to unnecessary runs, for example: WIP commits.

Solution is to trigger the workflow after PR approval only.

I guess merging rules should be updated (allow merge only if approved & workflow succeed). 