### PR TITLE
Add AnalytiksFactory

### DIFF
--- a/addon/analytiks-azureinsight/build.gradle
+++ b/addon/analytiks-azureinsight/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdk 33
 
     defaultConfig {
-        minSdk 24
+        minSdk 21
         targetSdk 33
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -30,7 +30,7 @@ android {
 }
 
 dependencies {
-    api project(':analytiks-core')
+    implementation project(':analytiks-core')
 
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'com.microsoft.azure:applicationinsights-android:1.0-beta.10'

--- a/analytiks/build.gradle
+++ b/analytiks/build.gradle
@@ -33,4 +33,8 @@ android {
 dependencies {
     implementation 'androidx.core:core-ktx:1.7.0'
     api project(':analytiks-core')
+    implementation project(path: ':addon:analytiks-mixpanel')
+    implementation project(path: ':addon:analytiks-azureinsight')
+    implementation project(path: ':addon:analytiks-googleanalytics')
+    implementation project(path: ':addon:analytiks-timber')
 }

--- a/analytiks/build.gradle
+++ b/analytiks/build.gradle
@@ -32,7 +32,7 @@ android {
 
 dependencies {
     implementation 'androidx.core:core-ktx:1.7.0'
-    api project(':analytiks-core')
+    implementation project(':analytiks-core')
     implementation project(path: ':addon:analytiks-mixpanel')
     implementation project(path: ':addon:analytiks-azureinsight')
     implementation project(path: ':addon:analytiks-googleanalytics')

--- a/analytiks/src/main/java/com/analytiks/AnalytiksFactory.kt
+++ b/analytiks/src/main/java/com/analytiks/AnalytiksFactory.kt
@@ -1,0 +1,52 @@
+package com.analytiks
+
+import android.os.Bundle
+import com.analityks.addon.azureinsight.AzureInsightAnalyticsClient
+import com.analytiks.addon.mixpanel.GoogleAnalyticsClient
+import com.analytiks.addon.mixpanel.MixpanelAnalyticsClient
+import com.analytiks.addon.timber.TimberLocalClient
+import org.json.JSONObject
+
+sealed class AnalytiksFactory private constructor() {
+
+    companion object {
+        @JvmStatic
+        fun createAzureInsightAnalyticsClient(instrumentationKey: String): AzureInsightAnalyticsClient {
+            return AzureInsightAnalyticsClient(instrumentationKey)
+        }
+
+        @JvmStatic
+        fun createGoogleAnalyticsClient(
+            isAnalyticsCollectionEnabled: Boolean = true,
+            sessionTimeoutDuration: Long? = null,
+            defaultEventParameters: Bundle? = null,
+        ): GoogleAnalyticsClient {
+            return GoogleAnalyticsClient(
+                isAnalyticsCollectionEnabled, sessionTimeoutDuration, defaultEventParameters
+            )
+        }
+
+        @JvmStatic
+        fun createMixpanelAnalyticsClient(
+            token: String,
+            optOutTrackingDefault: Boolean = false,
+            superProperties: JSONObject? = null,
+            instanceName: String? = null,
+            trackAutomaticEvents: Boolean = true,
+        ): MixpanelAnalyticsClient {
+            return MixpanelAnalyticsClient(
+                token,
+                optOutTrackingDefault,
+                superProperties,
+                instanceName,
+                trackAutomaticEvents
+            )
+        }
+
+        @JvmStatic
+        fun createTimberLocalClient(): TimberLocalClient {
+            return TimberLocalClient()
+        }
+    }
+
+}

--- a/analytiks/src/main/java/com/analytiks/AnalytiksFactory.kt
+++ b/analytiks/src/main/java/com/analytiks/AnalytiksFactory.kt
@@ -7,46 +7,44 @@ import com.analytiks.addon.mixpanel.MixpanelAnalyticsClient
 import com.analytiks.addon.timber.TimberLocalClient
 import org.json.JSONObject
 
-sealed class AnalytiksFactory private constructor() {
+object AnalytiksFactory {
 
-    companion object {
-        @JvmStatic
-        fun createAzureInsightAnalyticsClient(instrumentationKey: String): AzureInsightAnalyticsClient {
-            return AzureInsightAnalyticsClient(instrumentationKey)
-        }
+    @JvmStatic
+    fun createAzureInsightAnalyticsClient(instrumentationKey: String): AzureInsightAnalyticsClient {
+        return AzureInsightAnalyticsClient(instrumentationKey)
+    }
 
-        @JvmStatic
-        fun createGoogleAnalyticsClient(
-            isAnalyticsCollectionEnabled: Boolean = true,
-            sessionTimeoutDuration: Long? = null,
-            defaultEventParameters: Bundle? = null,
-        ): GoogleAnalyticsClient {
-            return GoogleAnalyticsClient(
-                isAnalyticsCollectionEnabled, sessionTimeoutDuration, defaultEventParameters
-            )
-        }
+    @JvmStatic
+    fun createGoogleAnalyticsClient(
+        isAnalyticsCollectionEnabled: Boolean = true,
+        sessionTimeoutDuration: Long? = null,
+        defaultEventParameters: Bundle? = null,
+    ): GoogleAnalyticsClient {
+        return GoogleAnalyticsClient(
+            isAnalyticsCollectionEnabled, sessionTimeoutDuration, defaultEventParameters
+        )
+    }
 
-        @JvmStatic
-        fun createMixpanelAnalyticsClient(
-            token: String,
-            optOutTrackingDefault: Boolean = false,
-            superProperties: JSONObject? = null,
-            instanceName: String? = null,
-            trackAutomaticEvents: Boolean = true,
-        ): MixpanelAnalyticsClient {
-            return MixpanelAnalyticsClient(
-                token,
-                optOutTrackingDefault,
-                superProperties,
-                instanceName,
-                trackAutomaticEvents
-            )
-        }
+    @JvmStatic
+    fun createMixpanelAnalyticsClient(
+        token: String,
+        optOutTrackingDefault: Boolean = false,
+        superProperties: JSONObject? = null,
+        instanceName: String? = null,
+        trackAutomaticEvents: Boolean = true,
+    ): MixpanelAnalyticsClient {
+        return MixpanelAnalyticsClient(
+            token,
+            optOutTrackingDefault,
+            superProperties,
+            instanceName,
+            trackAutomaticEvents
+        )
+    }
 
-        @JvmStatic
-        fun createTimberLocalClient(): TimberLocalClient {
-            return TimberLocalClient()
-        }
+    @JvmStatic
+    fun createTimberLocalClient(): TimberLocalClient {
+        return TimberLocalClient()
     }
 
 }

--- a/app/src/main/java/com/logitanalyticsapp/di/AppContainer.kt
+++ b/app/src/main/java/com/logitanalyticsapp/di/AppContainer.kt
@@ -1,14 +1,13 @@
 package com.logitanalyticsapp.di
 
 import com.analytiks.Analytiks
-import com.analytiks.addon.mixpanel.MixpanelAnalyticsClient
-import com.analytiks.addon.timber.TimberLocalClient
+import com.analytiks.AnalytiksFactory
 import com.analytiks.core.CoreAddon
 
 class AppContainer {
     private val clients: List<CoreAddon> = listOf(
-        TimberLocalClient(),
-        MixpanelAnalyticsClient(
+        AnalytiksFactory.createTimberLocalClient(),
+        AnalytiksFactory.createMixpanelAnalyticsClient(
             token = "test-key-goes-here",
             optOutTrackingDefault = true,
         ),


### PR DESCRIPTION
Exposing clients class directly to the user will lead to a tight coupling between the usercode and the library code, ie. any changes to the clients code need a second thought about user code that we don't control.

A typical lib for me, should have only a single API with user code, in that way the lib can improve freely with a single constraint is not to mach API methods.

in our case API is Analytiks module (addons & Analytiks core should be private and not exposed to the user).

To solve this I used the static factory design pattern. 
