### PR TITLE
Add property numbering to logEvent method with properties

### DIFF
--- a/addon/analytiks-timber/src/main/java/com/analytiks/addon/timber/TimberLocalClient.kt
+++ b/addon/analytiks-timber/src/main/java/com/analytiks/addon/timber/TimberLocalClient.kt
@@ -25,7 +25,17 @@ class TimberLocalClient : CoreAddon, EventsExtension, UserProfileExtension {
     }
 
     override fun logEvent(name: String, vararg properties: Param) {
-        Timber.tag(TAG).log(Log.INFO, "Event: $name -> props: [$properties]")
+        val logMessage = if (properties.isNotEmpty()) {
+            val propertyStrings = properties.mapIndexed { index, param ->
+                "${index + 1}. ${param.propertyName} : ${param.propertyValue}"
+            }.joinToString("\n")
+
+            "***** Event: $name -> props:\n$propertyStrings\n*****"
+        } else {
+            "***** Event: $name (No properties) *****"
+        }
+
+        Timber.tag(TAG).log(Log.INFO, logMessage)
     }
     override fun identify(userId: String) {
         Timber.tag(TAG).log(Log.INFO, "User has been identified by: $userId")


### PR DESCRIPTION
<img src="https://github.com/aminekarimii/analytiks/assets/48645937/383c52fe-0143-4137-a9b6-3c6a695fa303"  width="20%">

- Improve the readability of logs in Timber when a user clicks an event with props, and handle the possibility of having an empty list of props.